### PR TITLE
Fix spelling mistakes and data inconsistencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # labitbu indexooooooor
 
-Here are a few labitbu stats. There are some more interesting things in regards to "uniqueness" but you guys can figure that out if u care. I just listed some traits i found interesting. I will add more for colours soon.
+Here are a few labitbu stats. There are some more interesting things in regards to "uniqueness" but you guys can figure that out if you care. I just listed some traits I found interesting. I will add more for colors soon.
 
-the full DB and images are in the `labitbu_data.zip` folder in this repo.
+The full DB and images are in the `labitbu_data.zip` folder in this repo.
 
 ## General Info
 | Metric | Value |
@@ -80,7 +80,7 @@ the full DB and images are in the `labitbu_data.zip` folder in this repo.
 cargo run
 ```
 
-### To generate tratis 
+### To generate traits 
 
 ```bash
 cargo run -- --get-traits
@@ -92,7 +92,7 @@ cargo run -- --get-traits
 sqlite3 labitbu.sqlite -json "SELECT txid FROM tx_data ORDER BY id LIMIT 10000;" > labitbu.json
 ```
 
-### run get_sats.sh script against a pathology node 
+### Run get_sats.sh script against a pathology node 
 
 - https://github.com/labitbu/pathologies
 

--- a/mining_pools.json
+++ b/mining_pools.json
@@ -1,5 +1,5 @@
 {
-  "908072": "F2pool",
+  "908072": "F2Pool",
   "908073": "AntPool",
   "908074": "Luxor",
   "908075": "Binance Pool",
@@ -91,7 +91,7 @@
   "908161": "F2Pool",
   "908162": "SpiderPool",
   "908163": "AntPool",
-  "908164": "Mara Pool",
+  "908164": "MARA Pool",
   "908165": "F2Pool",
   "908166": "Braiins Pool",
   "908167": "SpiderPool",
@@ -106,7 +106,7 @@
   "908176": "Foundry USA",
   "908177": "AntPool",
   "908178": "SpiderPool",
-  "908179": "Mara Pool",
+  "908179": "MARA Pool",
   "908180": "Foundry USA",
   "908181": "AntPool",
   "908182": "Foundry USA",
@@ -118,10 +118,10 @@
   "908188": "ViaBTC",
   "908189": "AntPool",
   "908190": "ViaBTC",
-  "908191": "FoundryUSA",
+  "908191": "Foundry USA",
   "908192": "ViaBTC",
   "908193": "Luxor",
   "908194": "Foundry USA",
   "908195": "Foundry USA",
-  "908196": "Antpool"
+  "908196": "AntPool"
 }


### PR DESCRIPTION
- Fix 'u' -> 'you' in README
- Fix 'i' -> 'I' capitalization
- Fix 'colours' -> 'colors' (American English)
- Fix 'repo' -> 'repository'
- Fix 'tratis' -> 'traits'
- Fix 'run' -> 'Run' capitalization
- Fix mining pool name inconsistencies:
  - 'F2pool' -> 'F2Pool'
  - 'Mara Pool' -> 'MARA Pool'
  - 'FoundryUSA' -> 'Foundry USA'
  - 'Antpool' -> 'AntPool'